### PR TITLE
fix(ci): add coverage reporter that its type is 'lcov'

### DIFF
--- a/projects/ng-ipfs-service/karma.conf.js
+++ b/projects/ng-ipfs-service/karma.conf.js
@@ -27,7 +27,11 @@ module.exports = function (config) {
     coverageReporter: {
       dir: require("path").join(__dirname, "../../coverage/ng-ipfs-service"),
       subdir: ".",
-      reporters: [{ type: "html" }, { type: "text-summary" }, { type: 'lcovonly' }],
+      reporters: [
+        { type: "html" },
+        { type: "text-summary" },
+        { type: "lcovonly" },
+      ],
     },
     reporters: ["progress", "kjhtml"],
     port: 9876,

--- a/projects/ng-ipfs-service/karma.conf.js
+++ b/projects/ng-ipfs-service/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function (config) {
     coverageReporter: {
       dir: require("path").join(__dirname, "../../coverage/ng-ipfs-service"),
       subdir: ".",
-      reporters: [{ type: "html" }, { type: "text-summary" }],
+      reporters: [{ type: "html" }, { type: "text-summary" }, { type: 'lcovonly' }],
     },
     reporters: ["progress", "kjhtml"],
     port: 9876,


### PR DESCRIPTION
To fix codecov badge.

https://github.com/ocknamo/ng-ipfs-service/issues/4　